### PR TITLE
Working Refresh, Refresh Button, and Preferences Button

### DIFF
--- a/src/main/java/nitezh/ministock/activities/widget/WidgetProviderBase.java
+++ b/src/main/java/nitezh/ministock/activities/widget/WidgetProviderBase.java
@@ -119,9 +119,9 @@ public class WidgetProviderBase extends AppWidgetProvider {
     }
 
     private void handleTouch(Context context, int appWidgetId, String action) {
-        if (action.equals("LEFT")) {
+        if (action.equals("PREFERENCES")) {
             startPreferencesActivity(context, appWidgetId);
-        } else if (action.equals("RIGHT")) {
+        } else if (action.equals("REFRESH")) {
             UpdateType updateType = getUpdateTypeForTouchRight(context, appWidgetId);
             updateWidgetAsync(context, appWidgetId, updateType);
         }
@@ -155,9 +155,7 @@ public class WidgetProviderBase extends AppWidgetProvider {
                 case CustomAlarmManager.ALARM_UPDATE:
                     doScheduledUpdates(context);
                     break;
-
-                case "LEFT":
-                case "RIGHT":
+                case "PREFERENCES":
                     Bundle extras = intent.getExtras();
                     if (extras != null) {
                         int appWidgetId = extras.getInt(
@@ -166,7 +164,14 @@ public class WidgetProviderBase extends AppWidgetProvider {
                         handleTouch(context, appWidgetId, action);
                     }
                     break;
-
+                case "REFRESH":
+                    Bundle refExtras = intent.getExtras();
+                    if (refExtras != null) {
+                        int refAppWidgetId = refExtras.getInt(
+                                AppWidgetManager.EXTRA_APPWIDGET_ID,
+                                AppWidgetManager.INVALID_APPWIDGET_ID);
+                        handleTouch(context, refAppWidgetId, action);
+                    }
                 default:
                     super.onReceive(context, intent);
                     break;

--- a/src/main/java/nitezh/ministock/activities/widget/WidgetView.java
+++ b/src/main/java/nitezh/ministock/activities/widget/WidgetView.java
@@ -161,17 +161,23 @@ class WidgetView {
     }
 
     public void setOnClickPendingIntents() {
-        Intent leftTouchIntent = new Intent(this.context, WidgetProvider.class);
-        leftTouchIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, this.widget.getId());
-        leftTouchIntent.setAction("LEFT");
-        this.remoteViews.setOnClickPendingIntent(R.id.widget_left,
-                PendingIntent.getBroadcast(this.context, this.widget.getId(), leftTouchIntent, 0));
+        Intent openPrefsIntent = new Intent(this.context, WidgetProvider.class);
+        openPrefsIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, this.widget.getId());
+        openPrefsIntent.setAction("PREFERENCES");
+        this.remoteViews.setOnClickPendingIntent(R.id.prefs_but,
+                PendingIntent.getBroadcast(this.context, this.widget.getId(), openPrefsIntent, 0));
 
         Intent rightTouchIntent = new Intent(this.context, WidgetProvider.class);
         rightTouchIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, this.widget.getId());
         rightTouchIntent.setAction("RIGHT");
         this.remoteViews.setOnClickPendingIntent(R.id.widget_right,
                 PendingIntent.getBroadcast(this.context, this.widget.getId(), rightTouchIntent, 0));
+
+        Intent buttonClickIntent = new Intent(this.context, WidgetProvider.class);
+        buttonClickIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, this.widget.getId());
+        buttonClickIntent.setAction("REFRESH");
+        this.remoteViews.setOnClickPendingIntent(R.id.test_but,
+                PendingIntent.getBroadcast(this.context, this.widget.getId(), buttonClickIntent, 0));
     }
 
     private HashMap<WidgetProviderBase.ViewType, Boolean> getEnabledViews() {

--- a/src/main/res/layout/bonobo_widget_layout.xml
+++ b/src/main/res/layout/bonobo_widget_layout.xml
@@ -5,52 +5,46 @@
     android:layout_margin="10dp"
     android:backgroundTint="#111">
 
-    <!--
-    <ImageView
-        android:id="@+id/widget_bg"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:adjustViewBounds="false"
-        android:contentDescription="@string/_2x2_widget_background"
-        android:orientation="horizontal"
-        android:scaleType="fitXY"
-        android:src="@drawable/ministock_bg_transparent68" />
-    -->
-
-
-
-
     <LinearLayout
-        android:id="@+id/widget_left"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="#00ffffff"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:layout_gravity="center_horizontal">
+
+        <ListView
+            android:id="@+id/widgetCollectionList"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/ministock_bg_transparent68">
+        </ListView>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="#00ffffff"
+            android:orientation="horizontal"
+            android:layout_gravity="center_horizontal"
+            >
+        <Button
+            android:id="@+id/test_but"
+            android:layout_width="80dp"
+            android:layout_height="wrap_content"
+            android:text="REFRESH"
+            android:alpha="0.5"
+            android:textSize="10sp"
+            android:gravity="center"
+            />
+        <Button
+            android:id="@+id/prefs_but"
+            android:layout_width="95dp"
+            android:layout_height="wrap_content"
+            android:text="PREFERENCES"
+            android:alpha="0.5"
+            android:textSize="10sp"
+            android:gravity="center"
+            />
+        </LinearLayout>
     </LinearLayout>
-    <!--
-    <TextView
-        android:id="@+id/test_str"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
-    <Button
-        android:id="@+id/test_but"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="REFRESH"
-        android:gravity="center"
-        android:paddingLeft="10dp"
-        android:paddingRight="10dp"/>
-    -->
-    <ListView
-        android:id="@+id/widgetCollectionList"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@drawable/ministock_bg_transparent68">
-    </ListView>
-
-
-
-
 
 </FrameLayout>

--- a/src/main/res/layout/bonobo_widget_layout.xml
+++ b/src/main/res/layout/bonobo_widget_layout.xml
@@ -19,7 +19,7 @@
             android:background="@drawable/ministock_bg_transparent68">
         </ListView>
 
-        <LinearLayout
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="#00ffffff"
@@ -34,6 +34,7 @@
             android:alpha="0.5"
             android:textSize="10sp"
             android:gravity="center"
+            android:layout_alignParentLeft="true"
             />
         <Button
             android:id="@+id/prefs_but"
@@ -43,8 +44,9 @@
             android:alpha="0.5"
             android:textSize="10sp"
             android:gravity="center"
+            android:layout_alignParentRight="true"
             />
-        </LinearLayout>
+        </RelativeLayout>
     </LinearLayout>
 
 </FrameLayout>


### PR DESCRIPTION
In this commit, several things were added. In the previous commit, tapping inside the void space below the widget window was the only way to access the preferences. This commit introduces a Preferences button, which behaves as expected and improves usability. Additionally, a new Refresh button has been added below the widget window and it causes an instant refresh of the stocks without having to go into the preferences and clicking update.
This references issues #12 and #11.